### PR TITLE
Example docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+version: "3.9"
+services:
+  webserver:
+    image: lipanski/docker-static-website:latest
+    restart: always
+    ports:
+      - "3000:3000"
+    volumes:
+      - /data/web:/home/static
+      - ./httpd.conf:/home/static/httpd.conf:ro


### PR DESCRIPTION
Add an example `docker-compose.yml` file.

It would serve the "local" directory `/data/web` as web content.
Requires that an empty (or valid) `httpd.conf` is present in the current directory.