### PR TITLE
Use standalone busybox_HTTPD binary (-78 kB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /busybox
 COPY .config .
 
 # Compile
-RUN make
+RUN make && ./make_single_applets.sh
 
 # Create a non-root user to own the files and run our server
 RUN adduser -D static
@@ -31,8 +31,8 @@ EXPOSE 3000
 # Copy over the user
 COPY --from=builder /etc/passwd /etc/passwd
 
-# Copy the busybox static binary
-COPY --from=builder /busybox/busybox /
+# Copy the static binary
+COPY --from=builder /busybox/busybox_HTTPD /busybox_HTTPD
 
 # Use our non-root user
 USER static
@@ -50,4 +50,4 @@ COPY httpd.conf .
 # COPY . .
 
 # Run busybox httpd
-CMD ["/busybox", "httpd", "-f", "-v", "-p", "3000", "-c", "httpd.conf"]
+CMD ["/busybox_HTTPD", "-f", "-v", "-p", "3000", "-c", "httpd.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ WORKDIR /busybox
 # Copy the busybox build config (limited to httpd)
 COPY .config .
 
-# Compile and install busybox
-RUN make && make install
+# Compile
+RUN make
 
 # Create a non-root user to own the files and run our server
 RUN adduser -D static
@@ -32,7 +32,7 @@ EXPOSE 3000
 COPY --from=builder /etc/passwd /etc/passwd
 
 # Copy the busybox static binary
-COPY --from=builder /busybox/_install/bin/busybox /
+COPY --from=builder /busybox/busybox /
 
 # Use our non-root user
 USER static


### PR DESCRIPTION
This cuts 78 kB from the resulting image.

    latest  c9b8ecff5ff3   91 kB
    latest  3c3081954b2a  169 kB

Thanks @Jason-Clark-FG for the hint (https://github.com/lipanski/docker-static-website/pull/21#issuecomment-1795020116).

