### PR TITLE
Fix podman compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - /some/local/path:/home/static
-      - ./httpd.conf:/home/static/httpd.conf:ro
+      - /some/local/path:/home/static:Z
+      - ./httpd.conf:/home/static/httpd.conf:ro,Z
 ```
 
 Make sure to change `/some/local/path` to the path to your static files. Include an empty or valid `httpd.conf` file.


### PR DESCRIPTION
Podman requires proper SELinux labels for mounts. Since the volumes aren't shared with other containers I have added `Z` option.